### PR TITLE
fix: not always get last window

### DIFF
--- a/harmony/react_native_screenshot_prevent/src/main/ets/RNScreenShotPreventTurboModule.ts
+++ b/harmony/react_native_screenshot_prevent/src/main/ets/RNScreenShotPreventTurboModule.ts
@@ -1,73 +1,79 @@
 import type { TurboModuleContext } from '@rnoh/react-native-openharmony/ts';
 import { TM } from "@rnoh/react-native-openharmony/generated/ts"
-import { TurboModule} from '@rnoh/react-native-openharmony/ts'
+import { TurboModule } from '@rnoh/react-native-openharmony/ts'
 import window from '@ohos.window';
-// 权限获取
 import abilityAccessCtrl, { Context, PermissionRequestResult } from '@ohos.abilityAccessCtrl';
 import { BusinessError } from '@ohos.base';
 
 import Logger from './Logger'
-const TAG='测试windowClass'
-const TAG2='测试事件监听'
+const TAG = 'TestWindowInstance'
+const TAG2 = 'TestScreenshotListener'
+
 export class RNScreenShotPreventTurboModule extends TurboModule implements TM.NativeScreenShotPreventNativeModule.Spec {
   constructor(protected ctx: TurboModuleContext) {
     super(ctx);
-    this.initialize(this.ctx.uiAbilityContext)
   }
-  private windowClass:undefined|window.Window;
-  async initialize(ctx){
+
+  async getLastWindowInstance(ctx: Context) {
     const windowInstance = await window.getLastWindow(ctx);
     const windowInfo = windowInstance.getWindowProperties()
-    this.windowClass=windowInstance;
-    Logger.info(TAG, `获取到window实例：${JSON.stringify(windowInfo)}`)
+    Logger.info(TAG, `获取到 window 实例：${JSON.stringify(windowInfo)}`)
+    return windowInstance
   }
-  enabled_bn(enabled: boolean):void{
+
+  enabled_bn(enabled: boolean): void {
     // 获取权限
-    let atManager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
     let context: Context = this.ctx.uiAbilityContext;
-    atManager.requestPermissionsFromUser(context, ['ohos.permission.PRIVACY_WINDOW'], (err: BusinessError, data: PermissionRequestResult)=>{
-      if (err) {
-        Logger.info(`requestPermissionsFromUser fail, err->${JSON.stringify(err)}`);
-      } else {
-        Logger.info(TAG,`获取ohos.permission.PRIVACY_WINDOW权限信息`);
-        Logger.info(TAG,'data:' + JSON.stringify(data));
-        Logger.info(TAG,'data permissions:' + data.permissions);
-        Logger.info(TAG,'data authResults:' + data.authResults);
-        if(data.authResults.includes(0)){
-          Logger.info(TAG,'ohos.permission.PRIVACY_WINDOW权限申请成功');
-          try {
-            let promise = this.windowClass.setWindowPrivacyMode(enabled);
-            promise.then(()=> {
-              Logger.info(TAG,'Succeeded in setting the window to privacy mode.');
-            }).catch((err)=>{
-              Logger.info(TAG,'Failed to set the window to privacy mode. Cause: ' + JSON.stringify(err));
-            });
-          } catch (exception) {
-            Logger.info(TAG,'Failed to set the window to privacy mode. Cause:' + JSON.stringify(exception));
-          }
-        }else{
-          Logger.info(TAG,'ohos.permission.PRIVACY_WINDOW权限申请失败,错误码authResults:`${data.authResults}`');
+    let atManager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
+    atManager.requestPermissionsFromUser(context, ['ohos.permission.PRIVACY_WINDOW'],
+      (err: BusinessError, data: PermissionRequestResult) => {
+        if (err) {
+          Logger.info(`requestPermissionsFromUser fail, err -> ${JSON.stringify(err)}`);
+          return
         }
-      }
-    });
-  }
-  addListener_bn():void{
-      Logger.info(TAG2,'screenshot addListener_bn');
-      const rnInstance=this.ctx.rnInstance;
-      try {
-        this.windowClass.on('screenshot',()=>{
-          rnInstance.emitDeviceEvent('screenshot_did_happen',{})
+        Logger.info(TAG, `获取 ohos.permission.PRIVACY_WINDOW 权限信息`);
+        Logger.info(TAG, 'data: ' + JSON.stringify(data));
+        Logger.info(TAG, 'data permissions: ' + data.permissions);
+        Logger.info(TAG, 'data authResults: ' + data.authResults);
+        if (!data.authResults.includes(0)) {
+          Logger.info(TAG, `ohos.permission.PRIVACY_WINDOW 权限申请失败，错误码 authResults: ${data.authResults}`);
+          return
+        }
+        Logger.info(TAG, 'ohos.permission.PRIVACY_WINDOW 权限申请成功');
+        this.getLastWindowInstance(context)
+          .then(windowInstance => {
+            return windowInstance.setWindowPrivacyMode(enabled);
+          }).then(() => {
+          Logger.info(TAG, 'Succeeded in setting the window to privacy mode.');
+        }).catch((err) => {
+          Logger.info(TAG, 'Failed to set the window to privacy mode. Cause: ' + JSON.stringify(err));
         });
-      } catch (exception) {
-        Logger.error('Failed to register callback. Cause: ' + JSON.stringify(exception));
-      }
+      });
   }
-  removeListener_bn():void{
-    try {
-      // 如果通过on开启多个callback进行监听，同时关闭所有监听：
-      this.windowClass.off('screenshot');
-    } catch (exception) {
-      Logger.error('Failed to unregister callback. Cause: ' + JSON.stringify(exception));
-    }
+
+  addListener_bn(): void {
+    Logger.info(TAG2, 'screenshot addListener_bn');
+    this.getLastWindowInstance(this.ctx.uiAbilityContext)
+      .then(windowInstance => {
+        windowInstance.on('screenshot', () => {
+          Logger.info(TAG2, 'screenshot screenshot_did_happen');
+          this.ctx.rnInstance.emitDeviceEvent('screenshot_did_happen', {})
+        });
+      })
+      .catch(err => {
+        Logger.error('Failed to register callback. Cause: ' + JSON.stringify(err));
+      })
+  }
+
+  removeListener_bn(): void {
+    this.getLastWindowInstance(this.ctx.uiAbilityContext)
+      .then(windowInstance => {
+        // 如果通过 on 开启多个 callback 进行监听，同时关闭所有监听：
+        Logger.info(TAG2, 'screenshot off');
+        windowInstance.off('screenshot');
+      })
+      .catch(err => {
+        Logger.error('Failed to unregister callback. Cause: ' + JSON.stringify(err));
+      })
   }
 }


### PR DESCRIPTION
修复：并不总是拿最新的 window 实例

比如，当配合 [react-native-splash-screen](https://github.com/react-native-oh-library/react-native-splash-screen) 使用时，防截屏功能会失效。

因为原有的 `initialize` 方法初始化的 `windowClass` 拿到的是 `SplashScreenWindow` (https://github.com/react-native-oh-library/react-native-splash-screen/blob/d0b0f5ba58553167ea4dcf10d7bcaf70e6743b0e/harmony/splash_screen/src/main/ets/SplashScreen.ts#L66)。

所以写了新的方法 `getLastWindowInstance` 始终去拿最新的 window 实例，并格式化了代码。

已测试下面方法的调用：
- enabled_bn
- addListener_bn
- removeListener_bn 

测试代码：
```ts
import { useCallback, useEffect } from 'react'
import { useFocusEffect } from '@react-navigation/native'
import RNScreenshotPrevent from '@react-native-oh-tpl/react-native-screenshot-prevent'

export function useScreenshotPreventFocusEffect() {
  useFocusEffect(
    useCallback(() => {
      RNScreenshotPrevent.enabled(true)
      return () => {
        RNScreenshotPrevent.enabled(false)
      }
    }, [])
  )
}

export function useScreenshotPreventEffect(isEnabled: boolean) {
  useEffect(() => {
    if (!isEnabled) {
      return
    }
    RNScreenshotPrevent.enabled(true)
    return () => {
      RNScreenshotPrevent.enabled(false)
    }
  }, [isEnabled])
}

export function useScreenshotListenerEffect(callback: () => void) {
  useEffect(() => {
    const subscription = RNScreenshotPrevent.addListener(callback)
    return () => {
      subscription.remove()
    }
  }, [callback])
}
```

<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- 这个功能是什么？（如果适用）
- 您是如何实现解决方案的？
- 这个更改影响了库的哪些部分？

Explain the **motivation** for making this change: here are some points to help you:

- What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
- What is the feature? (if applicable)
- How did you implement the solution?
- What areas of the library does it impact?

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [ ] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
